### PR TITLE
Fix registration modal trigger on login screen

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -17,6 +17,18 @@
             <button id="btn-login">Entrar</button>
             <button id="btn-registrar">Registrar</button>
         </div>
+
+        <div id="modal-registrar-usuario" class="modal-overlay hidden">
+            <div class="modal-content">
+                <h3>Registrar Novo Usuário</h3>
+                <input type="text" id="registro-nome" placeholder="Nome">
+                <input type="text" id="registro-sobrenome" placeholder="Sobrenome">
+                <input type="email" id="registro-email" placeholder="E-mail">
+                <input type="password" id="registro-senha" placeholder="Senha">
+                <button id="btn-finalizar-registro">Cadastrar</button>
+                <button id="btn-fechar-registro-usuario" class="btn-secundario">Cancelar</button>
+            </div>
+        </div>
     </div>
 
     <div id="app-container" class="hidden">
@@ -265,18 +277,6 @@
 
                 <button id="btn-salvar-meta">Salvar Meta</button>
                 <button id="btn-fechar-meta-modal" class="btn-secundario">Cancelar</button>
-            </div>
-        </div>
-
-        <div id="modal-registrar-usuario" class="modal-overlay hidden">
-            <div class="modal-content">
-                <h3>Registrar Novo Usuário</h3>
-                <input type="text" id="registro-nome" placeholder="Nome">
-                <input type="text" id="registro-sobrenome" placeholder="Sobrenome">
-                <input type="email" id="registro-email" placeholder="E-mail">
-                <input type="password" id="registro-senha" placeholder="Senha">
-                <button id="btn-finalizar-registro">Cadastrar</button>
-                <button id="btn-fechar-registro-usuario" class="btn-secundario">Cancelar</button>
             </div>
         </div>
 

--- a/public/js/modules/auth.js
+++ b/public/js/modules/auth.js
@@ -57,6 +57,14 @@ export const handleAuthStateChanged = (user) => {
     const appContainer = document.getElementById('app-container');
     const userEmailSpan = document.getElementById('user-email');
 
+    if (!modalRegistrarUsuario) {
+        modalRegistrarUsuario = document.getElementById('modal-registrar-usuario');
+    }
+
+    if (modalRegistrarUsuario) {
+        modalRegistrarUsuario.classList.add('hidden');
+    }
+
     if (!authContainer || !appContainer || !userEmailSpan) {
         console.error("Erro: Elementos principais da interface não encontrados.");
         return;


### PR DESCRIPTION
## Summary
- Move user registration modal into login container so it appears only when "Registrar" is clicked
- Ensure registration modal hides on auth state changes

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689cc798e460832ea5288f52d36e7c8c